### PR TITLE
Carrierwave gem install, changes to photo & photo album

### DIFF
--- a/.ruby-gemset
+++ b/.ruby-gemset
@@ -1,1 +1,1 @@
-photo_app
+photo_clone

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'sass-rails', '~> 5.0'
 gem 'uglifier', '>= 1.3.0'
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'therubyracer', platforms: :ruby
-
+gem 'carrierwave'
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.2'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,10 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    carrierwave (1.1.0)
+      activemodel (>= 4.0.0)
+      activesupport (>= 4.0.0)
+      mime-types (>= 1.16)
     childprocess (0.7.1)
       ffi (~> 1.0, >= 1.0.11)
     coffee-rails (4.2.2)
@@ -200,6 +204,7 @@ DEPENDENCIES
   bootstrap-sass (~> 3.3.6)
   byebug
   capybara (~> 2.13)
+  carrierwave
   coffee-rails (~> 4.2)
   devise
   jbuilder (~> 2.5)

--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -1,0 +1,49 @@
+class AlbumsController < ApplicationController
+
+	def index 
+	@album = Album.all
+	end 
+
+	def show
+	@album = Album.find(params[:id])
+	end 
+
+	def new
+	@album = Album.new 
+	end
+
+	def create
+	album_params = params[:album].permit(:name, :description)
+	@album = Album.create(album_params)
+	redirect_to albums_path(id: @album.id)
+	end
+
+	def edit
+	@album = Album.find(params[:id])
+	end
+
+	def update
+	album_params = params[:album].permit(:name, :description)
+	album = Album.find(params[:id])
+	album.update(album_params)
+	redirect_to albums_path(id: album.id)
+	end
+
+	def destroy
+	@album = Album.find(params[:id])
+	@album.destroy
+	redirect_to albums_path
+	end
+
+end 
+
+
+
+
+
+
+
+
+
+
+

--- a/app/controllers/photos_controller.rb
+++ b/app/controllers/photos_controller.rb
@@ -1,0 +1,31 @@
+class PhotosController < ApplicationController
+
+	def photo_params
+	params.require(:photo).permit(:title, :description, :image)
+	end
+
+	def index 
+	end 
+
+	def show
+	@photo = Photo.new 
+	end 
+
+	def new
+	@photo = Photo.new 
+	end
+
+	def create
+	end
+
+	def edit
+	end
+
+	def update
+	end
+
+	def destroy
+	end
+
+
+end 

--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -1,0 +1,5 @@
+class Album < ApplicationRecord
+belongs_to :user, optional: true
+has_many :photos
+
+end

--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -1,0 +1,8 @@
+class Photo < ApplicationRecord
+  belongs_to :album
+  
+  validates_presence_of :title
+
+  mount_uploader :image, ImageUploader
+
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,7 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
+
+ has_many :albums
+
 end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,0 +1,49 @@
+class ImageUploader < CarrierWave::Uploader::Base
+
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  # include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add a white list of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  def extension_whitelist
+    %w(jpg jpeg gif png)
+  end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+
+end

--- a/app/views/albums/edit.html.erb
+++ b/app/views/albums/edit.html.erb
@@ -1,0 +1,26 @@
+<h1>Edit your Album</h1>
+<%= form_for @album, url: album_path, method: :patch do |f| %>
+ 	<div class = "row">
+ 	<%= f.label :name %>
+ 	</div>
+
+ 	<div class = "row">
+  	<%= f.text_field :name %>
+	</div>
+
+ 	<div class = "row">
+ 	<%= f.label :description %>
+ 	</div>
+
+ 	<div class = "row">
+  	<%= f.text_area :description %>
+	</div>
+	<p>
+	</p>
+
+	<div class = "row">
+  	<%= f.submit "Update" %>
+	</div>
+
+<% end %>
+

--- a/app/views/albums/index.html.erb
+++ b/app/views/albums/index.html.erb
@@ -1,0 +1,41 @@
+<table class = "table">
+	<thead>
+	<th> Album Name </th>
+	<th> Album Description </th>
+	<th> Edit </th>
+	<th> Delete </th>
+	</thead>
+
+	<tbody>
+		<% @album.each do|album| %> 
+			<tr>
+				<td>
+				<%= link_to album.name, album_path(id: album) %> 
+				</td>
+
+				<td>
+				Updated at <%= album.updated_at.strftime("%d %b %Y, %T") %>
+				</td>
+	
+				<td> 
+                <%= link_to edit_album_path(album), class: 'btn btn-primary btn-xs' do%>
+                <i class = "glyphicon glyphicon-pencil"></i> 
+                <%end%>
+				</td>
+	
+				<td>
+				<%= link_to album_path(album), 
+				method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger btn-xs' do%>
+                <i class = "glyphicon glyphicon-remove"></i> 
+                <%end%>
+				</td>
+			</tr>
+		<% end %> 
+	</tbody>
+</table>
+
+	<div>
+	<%= button_to "Create New Album", new_album_path, :method => "get" %>
+	</div>
+
+</div>

--- a/app/views/albums/new.html.erb
+++ b/app/views/albums/new.html.erb
@@ -1,0 +1,26 @@
+<h1>Create an Album</h1>
+<%= form_for @album, url: albums_path, method: :post do |f| %>
+ 	<div class = "row">
+ 	<%= f.label :name %>
+ 	</div>
+
+ 	<div class = "row">
+  	<%= f.text_field :name %>
+	</div>
+
+ 	<div class = "row">
+ 	<%= f.label :description %>
+ 	</div>
+
+ 	<div class = "row">
+  	<%= f.text_area :description %>
+	</div>
+	<p>
+	</p>
+
+	<div class = "row">
+  	<%= f.submit "Create" %>
+	</div>
+
+<% end %>
+

--- a/app/views/albums/show.html.erb
+++ b/app/views/albums/show.html.erb
@@ -1,0 +1,33 @@
+<h2><%= @album.name %></h2>
+		<table class = "table">
+			<thead>
+				<th> Album Name </th>
+				<th> Description </th>
+				<th> Updated </th>
+				<th> Edit </th>
+				<th> Delete </th>
+			</thead>
+
+			<tbody>
+				<tr>
+					<td>
+					<%= @album.name %> 
+					</td>
+					<td>
+					<%= @album.description %>
+					</td>
+					<td>
+					Updated at <%= @album.updated_at.strftime("%d %b %Y, %T") %>
+					</td>
+					<td>
+					<%= link_to edit_album_path(id: @album), class: 'btn btn-primary btn-xs' do%>
+                	<i class = "glyphicon glyphicon-pencil"></i> 
+                	<%end%>
+					</td>
+
+					<td>
+					<%= link_to album_path(id: @album), 
+					method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger btn-xs' do%>
+                	<i class = "glyphicon glyphicon-remove"></i> 
+                	<%end%>
+					</td>

--- a/app/views/photos/_form.html.erb
+++ b/app/views/photos/_form.html.erb
@@ -1,0 +1,13 @@
+<%= form_for @photo do |f| %>
+  
+  <div class="field">
+    <%= f.label :title %>
+    <%= f.text_field :title %>
+  </div>
+
+  <div class="field">
+    add an image....
+    <%= f.file_field :image %>
+  </div>
+
+end

--- a/app/views/photos/new.html.erb
+++ b/app/views/photos/new.html.erb
@@ -1,0 +1,31 @@
+<h1>UPLOAD A PHOTO</h1>
+
+<%= form_for @photo do |f| %>
+  
+  <div class="field">
+    <%= f.label :title %>
+    <div class = "row">
+    <%= f.text_field :title %>
+  </div>
+  </div>
+
+  
+   <div class="field">
+    <%= f.label :description %>
+    <div class = "row">
+    <%= f.text_area :description %>
+  </div>
+  </div>
+
+
+  <div class="field">
+    <%= f.label :image %>
+      <div class = "row">
+    <%= f.file_field :image %>
+  </div>
+  </div>
+
+  <div class = "row">
+  <%= f.submit "Create" %>
+  </div>
+  <%end%>

--- a/app/views/photos/show.html.erb
+++ b/app/views/photos/show.html.erb
@@ -1,0 +1,1 @@
+<%= image_tag(@photo.image_url.to_s) %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -51,5 +51,6 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  
 config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,11 @@
 Rails.application.routes.draw do
-  devise_for :users
+
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-	root to: "pages#home"
+root to: "pages#home"
+devise_for :users 
+
+resources :albums do 
+resources :photos
+end 
+
 end

--- a/db/migrate/20170913082737_create_photos.rb
+++ b/db/migrate/20170913082737_create_photos.rb
@@ -1,0 +1,7 @@
+class CreatePhotos < ActiveRecord::Migration[5.1]
+  def change
+    create_table :photos do |t|
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20170913092047_add_image_to_photos.rb
+++ b/db/migrate/20170913092047_add_image_to_photos.rb
@@ -1,0 +1,5 @@
+class AddImageToPhotos < ActiveRecord::Migration[5.1]
+  def change
+    add_column :photos, :image, :string
+  end
+end

--- a/db/migrate/20170913092237_add_title_to_photos.rb
+++ b/db/migrate/20170913092237_add_title_to_photos.rb
@@ -1,0 +1,5 @@
+class AddTitleToPhotos < ActiveRecord::Migration[5.1]
+  def change
+    add_column :photos, :title, :string
+  end
+end

--- a/db/migrate/20170913093340_add_description_to_photos.rb
+++ b/db/migrate/20170913093340_add_description_to_photos.rb
@@ -1,0 +1,5 @@
+class AddDescriptionToPhotos < ActiveRecord::Migration[5.1]
+  def change
+    add_column :photos, :description, :text
+  end
+end

--- a/db/migrate/20170913101700_create_albums.rb
+++ b/db/migrate/20170913101700_create_albums.rb
@@ -1,0 +1,10 @@
+class CreateAlbums < ActiveRecord::Migration[5.1]
+  def change
+    create_table :albums do |t|
+    	t.string :name
+    	t.text :description
+    	t.references :user, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,24 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170912063949) do
+ActiveRecord::Schema.define(version: 20170913101700) do
+
+  create_table "albums", force: :cascade do |t|
+    t.string "name"
+    t.text "description"
+    t.integer "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_albums_on_user_id"
+  end
+
+  create_table "photos", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "image"
+    t.string "title"
+    t.text "description"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false

--- a/test/fixtures/albums.yml
+++ b/test/fixtures/albums.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/photos.yml
+++ b/test/fixtures/photos.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/album_test.rb
+++ b/test/models/album_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class AlbumTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/photo_test.rb
+++ b/test/models/photo_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class PhotoTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
1.  Installed Carrierwave gem
2.  Rails g uploader image command (created Uploader folder in the App folder)
3.  Created Photo model 
4.  Mount image uploader to photo model & pass in the column name and the uploader class through model. Code below: 

`class Photo < ApplicationRecord
  belongs_to :album
  
  validates_presence_of :title

  mount_uploader :image, ImageUploader

end`

5.  Generated Photo migration file (image, title, description and timestamps)

6. In order to make Photo image accessible, added this code to Photos Controller file: 
`class PhotosController < ApplicationController

	def photo_params
	params.require(:photo).permit(:title, :description, :image)
	end

end 
`

7. Added code to Photos/show.html.erb
<%= image_tag(@photo.image_url.to_s) %>

8. Added photo input form into the Photos/new.html.erb view (and partial form)

9. Also included new code to enable working Album Index, Show, Edit/Update, New/Create and Destroy functionality
 (through changes to Album controller, Album routes, Album model, Album views)

10. Added has_many: albums in User Model 
